### PR TITLE
Run Lambda only for ObjectCreated events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ tmp/
 
 # EICAR Files
 *eicar*
+/.aws-sam/

--- a/scan.py
+++ b/scan.py
@@ -55,6 +55,10 @@ def event_object(event, event_source="s3"):
         raise Exception("No records found in event!")
     record = records[0]
 
+    if "ObjectCreated" not in record.get("eventName", ''):
+        print("Skipping non-ObjectCreated event types")
+        return None
+
     s3_obj = record["s3"]
 
     # Get the bucket name
@@ -212,6 +216,10 @@ def lambda_handler(event, context):
     start_time = get_timestamp()
     print("Script starting at %s\n" % (start_time))
     s3_object = event_object(event, event_source=EVENT_SOURCE)
+
+    # If event_type is not 'ObjectCreated' escape lambda
+    if s3_object is None:
+        return
 
     if str_to_bool(AV_PROCESS_ORIGINAL_VERSION_ONLY):
         verify_s3_object_version(s3, s3_object)


### PR DESCRIPTION
The PR should fix 2. item: https://github.com/solvebio/api.solvebio.com/issues/3205#issuecomment-1051105311

> The lambda does not filter based on the event type, so we get an infinite loop when the AV lambda tags something and then receives the SNS event for that tag event. It should filter and run only on s3:ObjectCreated events